### PR TITLE
feat: 공용 이슈 템플릿 Spec-driven 구조 확장 반영 #15

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-기능-개발.yml
+++ b/.github/ISSUE_TEMPLATE/01-기능-개발.yml
@@ -29,7 +29,7 @@ body:
     id: requirements
     attributes:
       label: "3. 요구 사항"
-      description: "만족해야 하는 조건을 체크박스로 정리"
+      description: "만족해야 하는 조건을 체크박스로 정리하세요. 필수 요구는 (필수), 추가 요구는 (선택) 태그로 구분합니다."
       placeholder: |
         - [ ] (필수) 관리자는 디바이스 소유권을 변경할 수 있어야 한다.
         - [ ] (필수) 관리자는 디바이스의 소유자를 알 수 있어야 한다.
@@ -62,5 +62,69 @@ body:
         - 관련 이슈/PR:
         - 레퍼런스 문서/스펙:
         - 스크린샷/로그:
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: "6. 수용 기준 (선택)"
+      description: "필요한 경우 Given/When/Then 형식과 AC 식별자(예: AC-01)로 작성"
+      placeholder: |
+        - [ ] AC-01: Given ... When ... Then ...
+        - [ ] AC-02: Given 요청 생성, When 처리 시작, Then 상태가 `REQUESTED`로 기록된다.
+        - [ ] AC-03: Given 실패 조건, When 타임아웃/검증 실패, Then `reasonCode`/`reasonMessage`를 조회할 수 있다.
+    validations:
+      required: false
+
+  - type: textarea
+    id: status_model
+    attributes:
+      label: "7. 상태 모델 (선택)"
+      description: "비동기 처리나 진행 상태 관리가 필요할 때 작성 (상태/전이/실패/재시도 포함)"
+      placeholder: |
+        - REQUESTED -> COMMAND_SENT -> DOWNLOADING -> INSTALLING -> REBOOTING -> SUCCEEDED
+        - 실패 전이: FAILED_VALIDATION | FAILED_DELIVERY | FAILED_DOWNLOAD | FAILED_INSTALL | FAILED_HEALTHCHECK | FAILED_TIMEOUT
+        - 정책상 재시도 시: FAILED_* -> REQUESTED
+        - 운영 상태: CANCELLED | ROLLED_BACK
+    validations:
+      required: false
+
+  - type: textarea
+    id: api_protocol
+    attributes:
+      label: "8. API/프로토콜 (선택)"
+      description: "외부/내부 연동 계약이 필요할 때 작성"
+      placeholder: |
+        - User API: GET /api/v1/... , POST /api/v1/...
+        - Admin API: POST /api/v1/admin/... (생성/중단/재개)
+        - Async channel: MQTT topic or webhook/event
+        - report payload: jobId, status, progress, reasonCode, reasonMessage, reportedAt
+    validations:
+      required: false
+
+  - type: textarea
+    id: data_model
+    attributes:
+      label: "9. 데이터 모델 (선택)"
+      description: "DB/스키마 영향이 있을 때 작성"
+      placeholder: |
+        - main entity/table: feature_job(job_id, status, attempt, requested_at, updated_at)
+        - history table: feature_job_history(job_id, from_status, to_status, reason_code, reason_message, changed_at)
+        - related artifact/config: version, target, checksum
+        - index/constraint/migration note:
+    validations:
+      required: false
+
+  - type: textarea
+    id: non_functional_requirements
+    attributes:
+      label: "10. 비기능 요구사항 (선택)"
+      description: "성능/안정성/운영 요구가 중요할 때 작성"
+      placeholder: |
+        - latency: 상태 변경 이벤트 처리 P95 < 5s
+        - api performance: 상태 조회 API P95 < 300ms
+        - reliability: 성공률/실패율 메트릭 수집 가능
+        - alarm: 실패율 임계치/타임아웃/DLQ 알람 발송
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/02-기능-개발---하위-태스크.yml
+++ b/.github/ISSUE_TEMPLATE/02-기능-개발---하위-태스크.yml
@@ -41,3 +41,27 @@ body:
         - 링크/스크린샷/로그 등
     validations:
       required: false
+
+  - type: textarea
+    id: detailed_acceptance_criteria
+    attributes:
+      label: 4. 상세 수용 기준 (선택)
+      description: 필요한 경우 Given/When/Then 형식으로 작성하세요.
+      placeholder: |
+        - Given ...
+        - When ...
+        - Then ...
+    validations:
+      required: false
+
+  - type: textarea
+    id: verification_logs
+    attributes:
+      label: 5. 검증 로그/링크 (선택)
+      description: 테스트 결과, 스크린샷, 로그 링크를 정리하세요.
+      placeholder: |
+        - 테스트 결과:
+        - 스크린샷:
+        - 로그 링크:
+    validations:
+      required: false


### PR DESCRIPTION
> 🤖 **AI created**

## 왜 이 PR이 필요한가
- 공용 Feature/Task 이슈 템플릿은 기본 체크리스트 중심이라 단순 작업에는 충분했지만, 복잡 기능에서는 핵심 계약 정보(수용 기준, 상태 전이, API/데이터/NFR)가 누락되기 쉬웠습니다.
- 이 누락은 구현 단계에서 요구사항 재해석을 유발하고, 리뷰 단계에서 "무엇을 검증해야 하는지" 기준이 흔들려 재작업 비용이 커지는 문제가 있었습니다.
- 따라서 이 PR은 `develop`에서 검증된 템플릿 구조 개선을 `main`에 반영해, 조직 공용 표준을 일관되게 유지하려는 목적입니다.

## 왜 Spec-driven development를 적용하는가
- **명세 선행 정렬**: 구현 전에 AC/상태/API/NFR를 합의해 팀과 에이전트가 동일한 완료 기준을 공유합니다.
- **리스크 조기 노출**: 상태 전이/실패 전이/운영 제약을 이슈 단계에서 드러내 설계 결함을 초기에 줄입니다.
- **검증 가능성 강화**: "요구 수집"이 아니라 "요구 충족 검증" 중심으로 리뷰가 가능해져 품질이 안정됩니다.
- **변경 비용 절감**: 모호한 요구로 인한 후반 재작업(스펙 보강, API 재협의, 테스트 재작성)을 줄입니다.

## 변경 내용
- `.github/ISSUE_TEMPLATE/01-기능-개발.yml`
  - 기존 필수 섹션(1~4) 유지, `5. 참고` 선택 유지
  - 선택 확장 섹션 5개 추가: `6. 수용 기준`, `7. 상태 모델`, `8. API/프로토콜`, `9. 데이터 모델`, `10. 비기능 요구사항`
  - `3. 요구 사항` 설명에 `(필수)/(선택)` 작성 규칙 명시
  - `sdm-backend#433` 문맥을 반영해 상태 모델/수용 기준/API/NFR placeholder 예시 보강
- `.github/ISSUE_TEMPLATE/02-기능-개발---하위-태스크.yml`
  - 기존 필수 섹션(상위 Feature, 1, 2) 유지, `3. 참고 (선택)` 유지
  - 선택 섹션 추가: `4. 상세 수용 기준`, `5. 검증 로그/링크`

## 기대 효과
- 단순 이슈는 기존처럼 빠르게 작성 가능(최소 입력 UX 유지)
- 복잡 이슈는 Spec-driven 입력으로 구현/리뷰 기준이 명확해짐
- Feature(스펙 허브)와 Task(실행 단위) 역할 분리가 강화됨

## 검증
- `develop..main` 범위 변경 파일: 이슈 템플릿 2개
- Template YAML 파싱 검증 완료 (`YAML_OK`)
- LSP diagnostics: 변경 파일 오류 없음

## 관련 이슈
- Related: #15